### PR TITLE
chore[#186300685] CSP Policy - Inline styling refactoring in templates

### DIFF
--- a/src/Helper/Renderer/MapHtmlRenderer.php
+++ b/src/Helper/Renderer/MapHtmlRenderer.php
@@ -43,19 +43,28 @@ class MapHtmlRenderer extends AbstractTagRenderer
 
     public function render(Map $map): string
     {
-        $styles = [];
-        $stylesheets = [
-            'width'  => $map->hasStylesheetOption('width') ? $map->getStylesheetOption('width') : '300px',
-            'height' => $map->hasStylesheetOption('height') ? $map->getStylesheetOption('height') : '300px',
-        ];
+        $styles      = [];
+        $stylesheets = [];
+        if ($map->hasStylesheetOption('width')) {
+            $stylesheets['width'] = $map->getStylesheetOption('width');
+        }
+
+        if ($map->hasStylesheetOption('height')) {
+            $stylesheets['height'] = $map->getStylesheetOption('height');
+        }
 
         foreach ($stylesheets as $stylesheet => $value) {
             $styles[] = $this->stylesheetRenderer->render($stylesheet, $value);
         }
 
-        return $this->getTagRenderer()->render('div', null, array_merge($map->getHtmlAttributes(), [
-            'id'    => $map->getHtmlId(),
-            'style' => implode('', $styles),
-        ]));
+        $attributes = array_merge($map->getHtmlAttributes(), [
+            'id' => $map->getHtmlId(),
+        ]);
+
+        if (!empty($stylesheets)) {
+            $attributes['style'] = implode('', $styles);
+        }
+
+        return $this->getTagRenderer()->render('div', null, $attributes);
     }
 }

--- a/tests/Helper/Renderer/MapHtmlRendererTest.php
+++ b/tests/Helper/Renderer/MapHtmlRendererTest.php
@@ -51,7 +51,7 @@ class MapHtmlRendererTest extends TestCase
     public function testRender()
     {
         $this->assertSame(
-            '<div id="map_canvas" style="width:300px;height:300px;"></div>',
+            '<div id="map_canvas"></div>',
             $this->mapHtmlRenderer->render(new Map())
         );
     }
@@ -74,7 +74,20 @@ class MapHtmlRendererTest extends TestCase
         $map->setHtmlAttributes(['class' => 'my-class']);
 
         $this->assertSame(
-            '<div class="my-class" id="map_canvas" style="width:300px;height:300px;"></div>',
+            '<div class="my-class" id="map_canvas"></div>',
+            $this->mapHtmlRenderer->render($map)
+        );
+    }
+
+    public function testRenderWithSizesAndAttributes()
+    {
+        $map = new Map();
+        $map->setStylesheetOption('width', '100px');
+        $map->setStylesheetOption('height', '200px');
+        $map->setHtmlAttributes(['class' => 'my-class']);
+
+        $this->assertSame(
+            '<div class="my-class" id="map_canvas" style="width:100px;height:200px;"></div>',
             $this->mapHtmlRenderer->render($map)
         );
     }
@@ -84,7 +97,7 @@ class MapHtmlRendererTest extends TestCase
         $this->mapHtmlRenderer->getFormatter()->setDebug(true);
 
         $this->assertSame(
-            '<div id="map_canvas" style="width: 300px;height: 300px;"></div>'."\n",
+            '<div id="map_canvas"></div>'."\n",
             $this->mapHtmlRenderer->render(new Map())
         );
     }


### PR DESCRIPTION
- Made the map sizes optional now as with CSP you no longer can use the style attribute